### PR TITLE
feat: 绑定原生ajax属性

### DIFF
--- a/pageScripts/index.js
+++ b/pageScripts/index.js
@@ -339,6 +339,9 @@ window.addEventListener("message", function (event) {
     ajax_tools_space[data.key] = data.value;
   }
   if (ajax_tools_space.ajaxToolsSwitchOn) {
+    for (const k in ajax_tools_space.originalXHR) {
+      ajax_tools_space.myXHR[k] = ajax_tools_space.originalXHR[k]
+    }
     window.XMLHttpRequest = ajax_tools_space.myXHR;
     window.fetch = ajax_tools_space.myFetch;
   } else {


### PR DESCRIPTION
开启插件后未配置拦截有些网站正常功能不能正确展示, 如B站的登陆信息。由于原生XMLHttpRequest属性未匹配, 如果业务代码 判断了这些属性就会出bug。如图所示：
![image](https://github.com/PengChen96/ajax-tools/assets/25600325/a4a4a838-078b-408f-979e-44e79019c40e)
